### PR TITLE
Fix JSON errors in Necromancy mod

### DIFF
--- a/data/mods/Necromancy/item_actions.json
+++ b/data/mods/Necromancy/item_actions.json
@@ -2,19 +2,16 @@
   {
     "type": "item_action",
     "id": "NECROMANCY_RESURRECT",
-    "name": "Resurrect as minion",
-    "menu_text": "Resurrect this corpse as your undead minion"
+    "name": "Resurrect as minion"
   },
   {
     "type": "item_action",
     "id": "NECROMANCY_COMMAND_FOLLOW",
-    "name": "Command to follow",
-    "menu_text": "Command your undead minions to follow you"
+    "name": "Command to follow"
   },
   {
     "type": "item_action",
     "id": "NECROMANCY_COMMAND_STAY",
-    "name": "Command to stay",
-    "menu_text": "Command your undead minions to stay here"
+    "name": "Command to stay"
   }
 ]

--- a/data/mods/Necromancy/items.json
+++ b/data/mods/Necromancy/items.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "necromancy_tome",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
     "name": { "str": "Tome of Necromancy" },
     "description": "A dark tome containing forbidden knowledge of death magic and undead control.",
     "weight": "1200 g",


### PR DESCRIPTION
# Fix JSON errors in Necromancy mod

## Problem
The Necromancy mod was causing game-breaking JSON errors during character creation:

1. **Invalid `menu_text` field in item_actions.json** - Lines 6, 12, and 18 contained `menu_text` fields which are not valid in CDDA's item_action structure
2. **Incorrect book type format in items.json** - Line 4 used `"type": "BOOK"` instead of the proper CDDA format `"type": "ITEM"` with `"subtypes": ["BOOK"]`

## Solution
- **Fixed item_actions.json**: Removed all invalid `menu_text` fields from the three necromancy item actions (NECROMANCY_RESURRECT, NECROMANCY_COMMAND_FOLLOW, NECROMANCY_COMMAND_STAY)
- **Fixed items.json**: Changed necromancy tome from `"type": "BOOK"` to `"type": "ITEM"` with `"subtypes": ["BOOK"]` following established CDDA conventions

## Testing
- ✅ JSON syntax validation passed for both files
- ⏳ Game loading and character creation test pending

## Changes Made
- `data/mods/Necromancy/item_actions.json`: Removed 3 invalid `menu_text` fields
- `data/mods/Necromancy/items.json`: Updated book type format to match CDDA standards

The fixes follow established patterns from core CDDA files like `data/json/item_actions.json` and `data/json/items/book/*.json`.

---

**Link to Devin run**: https://app.devin.ai/sessions/7cdd3f01ca254d3a89e0bcecf35bd10f  
**Requested by**: Noah Hicks (noah@photecpower.com)
