### PR TITLE
Fix JSON syntax errors in Necromancy mod

### DIFF
--- a/data/mods/Necromancy/items.json
+++ b/data/mods/Necromancy/items.json
@@ -12,16 +12,17 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "dark_gray",
-    "skill": "necromancy",
+    "read_skill": "necromancy",
     "required_level": 0,
     "max_level": 5,
     "intelligence": 8,
     "time": "30 m",
-    "fun": -2
+    "read_fun": -2
   },
   {
     "id": "necromancy_staff",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
     "name": { "str": "Necromantic Staff" },
     "description": "A gnarled staff imbued with dark energy. It helps focus necromantic spells.",
     "weight": "1500 g",


### PR DESCRIPTION
# Fix JSON syntax errors in Necromancy mod

This PR fixes the JSON parsing errors in the Necromancy mod's items.json file that were preventing the game from loading properly.

## Changes Made

- **Fixed book item fields**: Changed `"skill"` to `"read_skill"` and `"fun"` to `"read_fun"` to match the game's expected field names for book items
- **Fixed tool item structure**: Updated the necromancy staff from `"type": "TOOL"` to `"type": "ITEM"` with `"subtypes": ["TOOL"]` to align with the current item system

## Errors Fixed

The following JSON errors were resolved:
- Line 15: Invalid field name "skill" → changed to "read_skill" 
- Line 20: Invalid field name "fun" → changed to "read_fun"
- Line 24: Unrecognized JSON object type "TOOL" → changed to proper subtype structure

## Testing

The JSON structure now aligns with Cataclysm-DDA's item system requirements. The book item already had the correct `"type": "ITEM"` with `"subtypes": ["BOOK"]` structure, and the tool item has been updated to match this pattern.

---

**Link to Devin run**: https://app.devin.ai/sessions/9bd547135c7e45e1a770cd7bdf6ef33a  
**Requested by**: Noah Hicks (noah@photecpower.com)
