### PR TITLE
Fix necromancy mod JSON validation error

### DIFF
--- a/data/mods/Necromancy/monsters.json
+++ b/data/mods/Necromancy/monsters.json
@@ -27,7 +27,6 @@
     "placate_triggers": [ "PLAYER_ALLY" ],
     "starting_ammo": {  },
     "upgrades": false,
-    "reproduction": false,
     "baby_monster": null,
     "biosignature": { "biosig_item": "fp_loyalty_card", "biosig_factor": 3 },
     "petfood": { "food": [ "FLESH" ], "feed": "You feed your undead minion some flesh.", "pet": "You pat your undead minion." }
@@ -46,7 +45,6 @@
     "placate_triggers": [ "PLAYER_ALLY" ],
     "starting_ammo": {  },
     "upgrades": false,
-    "reproduction": false,
     "baby_monster": null,
     "petfood": { "food": [ "FLESH" ], "feed": "You feed your undead minion some flesh.", "pet": "You pat your undead minion." }
   },
@@ -64,7 +62,6 @@
     "placate_triggers": [ "PLAYER_ALLY" ],
     "starting_ammo": {  },
     "upgrades": false,
-    "reproduction": false,
     "baby_monster": null,
     "petfood": { "food": [ "FLESH" ], "feed": "You feed your undead minion some flesh.", "pet": "You pat your undead minion." }
   },
@@ -82,7 +79,6 @@
     "placate_triggers": [ "PLAYER_ALLY" ],
     "starting_ammo": {  },
     "upgrades": false,
-    "reproduction": false,
     "baby_monster": null,
     "petfood": { "food": [ "FLESH" ], "feed": "You feed your undead minion some flesh.", "pet": "You pat your undead minion." }
   }


### PR DESCRIPTION
# Fix necromancy mod JSON validation error

## Problem
The necromancy mod was causing a JSON validation error during game loading:
```
DEBUG : Error: Json error: file data/mods/Necromancy/monsters.json, at line 30, character 20:
Expected an object, got bool

    "starting_ammo": {  },
    "upgrades": false,
    "reproduction": false,
                  ^^^
```

## Solution
Removed the invalid `"reproduction": false` entries from all 4 monster definitions in the necromancy mod:
- `necromancy_undead_minion_base` (abstract base)
- `mon_necromancy_zombie_minion`
- `mon_necromancy_dog_minion` 
- `mon_necromancy_bear_minion`

According to CDDA documentation, the `reproduction` field expects an object with `baby_count`, `baby_timer`, and `baby_type` fields when present. For undead minions that don't reproduce, the correct approach is to omit the field entirely rather than setting it to `false`.

## Testing
- JSON syntax is now valid
- Follows proper CDDA monster schema requirements
- Aligns with existing monster definitions in the codebase

## Link to Devin run
https://app.devin.ai/sessions/3e842051c05e419cb7d9f72c58a81926

## Requested by
Noah Hicks (noah@photecpower.com)
