### PR TITLE
Fix necromancy scenario: add missing vision_levels and travel_cost_type fields

### DIFF
--- a/data/mods/Necromancy/overmap_terrain.json
+++ b/data/mods/Necromancy/overmap_terrain.json
@@ -5,10 +5,12 @@
     "name": "necromancy testing ground",
     "sym": "N",
     "color": "dark_gray",
+    "vision_levels": "isolated_building",
     "see_cost": "medium",
     "extras": "field",
     "mondensity": 2,
     "spawns": { "group": "GROUP_ZOMBIE", "population": [ 0, 1 ], "chance": 50 },
+    "travel_cost_type": "field",
     "flags": [ "KNOWN_DOWN" ]
   }
 ]


### PR DESCRIPTION
# Fix necromancy scenario location generation error

## Problem
The necromancy scenario was failing to start with the error:
```
Unable to generate a valid starting location Necromancy Testing Ground
[necromancy_test_location] in a radius of 3 overmaps, please report this
failure.
```

## Root Cause
The necromancy overmap terrain definition in `data/mods/Necromancy/overmap_terrain.json` was missing two required fields that are present in all working overmap terrain examples:
- `vision_levels` - Controls how the terrain appears on the overmap
- `travel_cost_type` - Defines movement cost for pathfinding and travel

## Solution
Added the missing fields to the necromancy overmap terrain definition:
- `"vision_levels": "isolated_building"` - Appropriate for an enclosed building structure as shown in the mapgen
- `"travel_cost_type": "field"` - Standard for non-road terrain that can be traversed

The values chosen match similar enclosed structures in the game and follow the exact same JSON structure and field patterns as working overmap terrain definitions in `data/json/overmap/overmap_terrain/`.

## Testing
The fix addresses the specific error by ensuring the overmap terrain has all required fields for proper generation and placement. The necromancy scenario should now start without the location generation error.

## Files Changed
- `data/mods/Necromancy/overmap_terrain.json` - Added missing `vision_levels` and `travel_cost_type` fields

---

**Link to Devin run:** https://app.devin.ai/sessions/eeb0fb379dc3402184fadd2bd243f560

**Requested by:** Noah Hicks (noah@photecpower.com)
