### PR TITLE
Make Magiclysm summons become follower pets

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -119,7 +119,7 @@
     "max_range": 3,
     "min_aoe": 2,
     "max_aoe": 2,
-    "flags": [ "CONJURATION_SPELL", "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET", "PERMANENT" ]
+    "flags": [ "CONJURATION_SPELL", "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET", "PERMANENT", "PET_SUMMON" ]
   },
   {
     "id": "summon_zombie",
@@ -240,7 +240,7 @@
     "max_range": 3,
     "min_aoe": 2,
     "max_aoe": 2,
-    "flags": [ "CONJURATION_SPELL", "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET", "PERMANENT" ]
+    "flags": [ "CONJURATION_SPELL", "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET", "PERMANENT", "PET_SUMMON" ]
   },
   {
     "id": "summon_zombie_dog",

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -152,6 +152,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::NO_PROJECTILE: return "NO_PROJECTILE";
         case spell_flag::HOSTILE_SUMMON: return "HOSTILE_SUMMON";
         case spell_flag::HOSTILE_50: return "HOSTILE_50";
+        case spell_flag::PET_SUMMON: return "PET_SUMMON";
         case spell_flag::FRIENDLY_POLY: return "FRIENDLY_POLY";
         case spell_flag::POLYMORPH_GROUP: return "POLYMORPH_GROUP";
         case spell_flag::SILENT: return "SILENT";

--- a/src/magic.h
+++ b/src/magic.h
@@ -54,6 +54,7 @@ enum class spell_flag : int {
     SWAP_POS, // a projectile spell swaps the positions of the caster and target
     HOSTILE_SUMMON, // summon spell always spawns a hostile monster
     HOSTILE_50, // summoned monster spawns friendly 50% of the time
+    PET_SUMMON, // summoned monster starts as a pet that follows the caster
     POLYMORPH_GROUP, // polymorph spell chooses a monster from a group
     FRIENDLY_POLY, // polymorph spell makes the monster friendly
     SILENT, // spell makes no noise at target

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -73,6 +73,7 @@
 class translation;
 
 static const efftype_id effect_teleglow( "teleglow" );
+static const efftype_id effect_pet( "pet" );
 
 static const flag_id json_flag_FIT( "FIT" );
 
@@ -1333,7 +1334,10 @@ static bool add_summoned_mon( const tripoint_bub_ms &pos, const time_duration &t
     }
     const bool permanent = sp.has_flag( spell_flag::PERMANENT );
     monster &spawned_mon = *mon_ptr;
-    if( is_summon_friendly( sp ) ) {
+    if( sp.has_flag( spell_flag::PET_SUMMON ) || ( caster.is_avatar() && is_summon_friendly( sp ) ) ) {
+        spawned_mon.friendly = -1;
+        spawned_mon.add_effect( effect_pet, 1_turns, true );
+    } else if( is_summon_friendly( sp ) ) {
         spawned_mon.friendly = INT_MAX;
     } else {
         spawned_mon.friendly = 0;


### PR DESCRIPTION
## Summary
- add `PET_SUMMON` spell flag and map it to string conversions
- make summoned monsters tamed when cast by the avatar or with the new flag
- mark core Magiclysm summon spells with `PET_SUMMON`

## Testing
- `make astyle-check` *(fails: astyle missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869c12200c08328aeaf11eda9be7807